### PR TITLE
Add Ollama client

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -143,6 +143,13 @@ model_list:
     base_url: "https://api.anthropic.com/v1"  # Replace with your API endpoint
     api_key: $ANTHROPIC_API_KEY
     max_concurrent_requests: 5
+
+  # Local Ollama server
+  - model_name: llama3
+    provider: ollama
+    base_url: "http://localhost:11434/v1"
+    api_key: null
+    max_concurrent_requests: 1
 ```
 
 ### Options

--- a/docs/USING_OPENAI_COMPATIBLE_MODELS.md
+++ b/docs/USING_OPENAI_COMPATIBLE_MODELS.md
@@ -19,6 +19,13 @@ model_list:
     base_url: "https://api.anthropic.com/v1/"  # Replace with your API endpoint
     api_key: $ANTHROPIC_API_KEY
     max_concurrent_requests: 5
+
+  # Local Ollama server (OpenAI compatible)
+  - model_name: llama3
+    provider: ollama
+    base_url: "http://localhost:11434/v1"
+    api_key: null
+    max_concurrent_requests: 1
 ```
 
 ## Environment Variables

--- a/example/configs/advanced_example.yaml
+++ b/example/configs/advanced_example.yaml
@@ -76,6 +76,13 @@ model_list:
     max_concurrent_requests: 128
     # This is good if you want to batch many requests and your system can handle it.
 
+  # 2b) Using a local Ollama server
+  - model_name: llama3
+    provider: ollama
+    base_url: http://localhost:11434/v1
+    api_key: null
+    max_concurrent_requests: 1
+
   # 3) Using an OpenAI model:
   - model_name: gpt-4.1
     base_url: https://api.openai.com/v1

--- a/yourbench/utils/inference_engine.py
+++ b/yourbench/utils/inference_engine.py
@@ -19,6 +19,7 @@ from loguru import logger
 from tqdm.asyncio import tqdm_asyncio
 
 from huggingface_hub import AsyncInferenceClient
+from .ollama_client import AsyncOllamaClient
 
 
 load_dotenv()
@@ -46,6 +47,9 @@ class Model:
     def __post_init__(self):
         if self.api_key is None:
             self.api_key = os.getenv("HF_TOKEN", None)
+        if self.provider == "ollama" and self.base_url is None:
+            # Default base URL for local Ollama server
+            self.base_url = "http://localhost:11434/v1"
 
 
 @dataclass
@@ -189,14 +193,22 @@ async def _get_response(model: Model, inference_call: InferenceCall) -> str:
 
     request_id = str(uuid.uuid4())
 
-    client = AsyncInferenceClient(
-        base_url=model.base_url,
-        api_key=model.api_key,
-        provider=model.provider,
-        bill_to=model.bill_to,
-        timeout=GLOBAL_TIMEOUT,
-        headers={"X-Request-ID": request_id},
-    )
+    if model.provider == "ollama":
+        client = AsyncOllamaClient(
+            base_url=model.base_url,
+            api_key=model.api_key,
+            timeout=GLOBAL_TIMEOUT,
+            headers={"X-Request-ID": request_id},
+        )
+    else:
+        client = AsyncInferenceClient(
+            base_url=model.base_url,
+            api_key=model.api_key,
+            provider=model.provider,
+            bill_to=model.bill_to,
+            timeout=GLOBAL_TIMEOUT,
+            headers={"X-Request-ID": request_id},
+        )
 
     logger.debug(f"Making request with ID: {request_id}")
 

--- a/yourbench/utils/ollama_client.py
+++ b/yourbench/utils/ollama_client.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+from dataclasses import dataclass
+
+import httpx
+
+
+@dataclass
+class AsyncOllamaClient:
+    """Minimal async client for Ollama's OpenAI-compatible API."""
+
+    base_url: str = "http://localhost:11434/v1"
+    api_key: str | None = None
+    timeout: float = 300
+    headers: Dict[str, str] | None = None
+
+    async def chat_completion(
+        self,
+        *,
+        model: str,
+        messages: List[Dict[str, str]],
+        temperature: Optional[float] = None,
+        seed: Optional[int] = None,
+    ) -> Any:
+        url = f"{self.base_url.rstrip('/')}/chat/completions"
+        payload: Dict[str, Any] = {"model": model, "messages": messages}
+        if temperature is not None:
+            payload["temperature"] = temperature
+        if seed is not None:
+            payload["seed"] = seed
+
+        req_headers = {"Content-Type": "application/json"}
+        if self.headers:
+            req_headers.update(self.headers)
+        if self.api_key:
+            req_headers["Authorization"] = f"Bearer {self.api_key}"
+
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            response = await client.post(url, json=payload, headers=req_headers)
+            response.raise_for_status()
+            data = response.json()
+
+        return SimpleNamespace(**data)


### PR DESCRIPTION
## Summary
- support Ollama via a new `AsyncOllamaClient`
- default Ollama base URL when provider is `ollama`
- document using Ollama in config examples

## Testing
- `ruff format yourbench/utils/inference_engine.py`
- `ruff format yourbench/utils/ollama_client.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'datasets')*

------
https://chatgpt.com/codex/tasks/task_b_683f4ec8106c833394a5b00868a87bc8