### PR TITLE
Add vLLM API client support

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -153,11 +153,13 @@ For each model in the list, you can specify:
   - **Required**: Yes  
   - **Description**: The identifier or name of the model (e.g., `gpt-4o`, `Qwen/Qwen2.5-VL-72B-Instruct`).
 
-- **`provider`**  
-  - **Type**: String  
-  - **Optional**: Yes  
-  - **Default**: `null`  
-  - **Description**: For Hugging Face models, specifies the inference provider (e.g., `hf-inference`, `novita`, `together`). Set to `null` for OpenAI API or OpenAI-compatible endpoints.
+- **`provider`**
+  - **Type**: String
+  - **Optional**: Yes
+  - **Default**: `null`
+  - **Description**: For Hugging Face models, specifies the inference provider (e.g., `hf-inference`, `novita`, `together`).
+    Use `vllm` to target a local [vLLM](https://github.com/vllm-project/vllm) server.
+    Set to `null` for OpenAI API or other OpenAI-compatible endpoints.
 
 - **`api_key`**  
   - **Type**: String  

--- a/docs/USING_VLLM_API_CLIENT.md
+++ b/docs/USING_VLLM_API_CLIENT.md
@@ -1,0 +1,15 @@
+# Using the vLLM API Client
+
+YourBench can talk to a self-hosted [vLLM](https://github.com/vllm-project/vllm) server by setting
+`provider: vllm` and providing the server URL via `base_url` in your configuration.
+
+```yaml
+model_list:
+  - model_name: Qwen/Qwen3-4B
+    provider: vllm
+    base_url: "http://localhost:8000/v1"
+    api_key: $VLLM_API_KEY  # optional if your server does not require one
+```
+
+The vLLM server exposes an OpenAI-compatible `/chat/completions` endpoint. The new
+client will be used automatically when `provider` is set to `vllm`.

--- a/tests/integration/test_pipeline.py
+++ b/tests/integration/test_pipeline.py
@@ -391,9 +391,10 @@ def test_finreg_code_generation_stage(mock_config):
     Verifies that code is generated and saved for each document.
     """
     from datasets import Dataset
+
     mock_dataset = Dataset.from_dict({
         "regulation_text": ["Regulation 1", "Regulation 2"],
-        "xml_code": ["<xml>1</xml>", "<xml>2</xml>"]
+        "xml_code": ["<xml>1</xml>", "<xml>2</xml>"],
     })
     with (
         patch("yourbench.utils.dataset_engine.custom_load_dataset", return_value=mock_dataset) as mock_load,
@@ -404,6 +405,7 @@ def test_finreg_code_generation_stage(mock_config):
             "fake_model": ["<output_code>code1</output_code>", "<output_code>code2</output_code>"]
         }
         from yourbench.pipeline.finreg_code_generation import run
+
         run(mock_config)
         mock_load.assert_called_once()
         mock_run_inference.assert_called_once()
@@ -416,9 +418,10 @@ def test_finreg_json_generation_stage(mock_config):
     Verifies that JSON is generated and saved for each document.
     """
     from datasets import Dataset
+
     mock_dataset = Dataset.from_dict({
         "regulation_text": ["Regulation 1", "Regulation 2"],
-        "xml_code": ["<xml>1</xml>", "<xml>2</xml>"]
+        "xml_code": ["<xml>1</xml>", "<xml>2</xml>"],
     })
     with (
         patch("yourbench.utils.dataset_engine.custom_load_dataset", return_value=mock_dataset) as mock_load,
@@ -429,6 +432,7 @@ def test_finreg_json_generation_stage(mock_config):
             "fake_model": ["<output_json>{}1</output_json>", "<output_json>{}2</output_json>"]
         }
         from yourbench.pipeline.finreg_json_generation import run
+
         run(mock_config)
         mock_load.assert_called_once()
         mock_run_inference.assert_called_once()

--- a/yourbench/pipeline/finreg_code_generation.py
+++ b/yourbench/pipeline/finreg_code_generation.py
@@ -1,9 +1,11 @@
-import os
-from typing import Dict, Any
+from typing import Any, Dict
+
 from loguru import logger
+
 from yourbench.utils.prompts import FINREG_CODE_GEN_PROMPT
-from yourbench.utils.inference_engine import InferenceCall, run_inference
 from yourbench.utils.dataset_engine import custom_load_dataset, custom_save_dataset
+from yourbench.utils.inference_engine import InferenceCall, run_inference
+
 
 def run(config: Dict[str, Any]) -> None:
     stage_cfg = config.get("pipeline", {}).get("finreg_code_generation", {})
@@ -39,4 +41,4 @@ def run(config: Dict[str, Any]) -> None:
     # Add generated code to dataset
     dataset = dataset.add_column("generated_code", responses)
     custom_save_dataset(dataset, config=config, subset=output_subset)
-    logger.success(f"Saved code generation results to subset '{output_subset}'.") 
+    logger.success(f"Saved code generation results to subset '{output_subset}'.")

--- a/yourbench/pipeline/finreg_json_generation.py
+++ b/yourbench/pipeline/finreg_json_generation.py
@@ -1,9 +1,11 @@
-import os
-from typing import Dict, Any
+from typing import Any, Dict
+
 from loguru import logger
+
 from yourbench.utils.prompts import FINREG_JSON_GEN_PROMPT
-from yourbench.utils.inference_engine import InferenceCall, run_inference
 from yourbench.utils.dataset_engine import custom_load_dataset, custom_save_dataset
+from yourbench.utils.inference_engine import InferenceCall, run_inference
+
 
 def run(config: Dict[str, Any]) -> None:
     stage_cfg = config.get("pipeline", {}).get("finreg_json_generation", {})
@@ -39,4 +41,4 @@ def run(config: Dict[str, Any]) -> None:
     # Add generated JSON to dataset
     dataset = dataset.add_column("generated_json", responses)
     custom_save_dataset(dataset, config=config, subset=output_subset)
-    logger.success(f"Saved JSON generation results to subset '{output_subset}'.") 
+    logger.success(f"Saved JSON generation results to subset '{output_subset}'.")

--- a/yourbench/utils/inference_engine.py
+++ b/yourbench/utils/inference_engine.py
@@ -19,6 +19,7 @@ from loguru import logger
 from tqdm.asyncio import tqdm_asyncio
 
 from huggingface_hub import AsyncInferenceClient
+from yourbench.utils.vllm_client import chat_completion as vllm_chat_completion
 
 
 load_dotenv()
@@ -189,32 +190,39 @@ async def _get_response(model: Model, inference_call: InferenceCall) -> str:
 
     request_id = str(uuid.uuid4())
 
-    client = AsyncInferenceClient(
-        base_url=model.base_url,
-        api_key=model.api_key,
-        provider=model.provider,
-        bill_to=model.bill_to,
-        timeout=GLOBAL_TIMEOUT,
-        headers={"X-Request-ID": request_id},
-    )
-
     logger.debug(f"Making request with ID: {request_id}")
 
-    response = await client.chat_completion(
-        model=model.model_name,
-        messages=inference_call.messages,
-        temperature=inference_call.temperature,
-        # Note: seed is not directly supported by chat_completion in huggingface_hub client API as of recent versions
-        # It might need to be passed via extra_body if the provider supports it.
-        # seed=inference_call.seed, # This might cause an error if not supported
-    )
+    if model.provider == "vllm":
+        output_content = await vllm_chat_completion(
+            base_url=model.base_url or "",
+            api_key=model.api_key,
+            model=model.model_name,
+            messages=inference_call.messages,
+            temperature=inference_call.temperature,
+            timeout=GLOBAL_TIMEOUT,
+            request_id=request_id,
+        )
+    else:
+        client = AsyncInferenceClient(
+            base_url=model.base_url,
+            api_key=model.api_key,
+            provider=model.provider,
+            bill_to=model.bill_to,
+            timeout=GLOBAL_TIMEOUT,
+            headers={"X-Request-ID": request_id},
+        )
 
-    # Safe-guarding in case the response is missing .choices
-    if not response or not response.choices:
-        logger.warning("Empty response or missing .choices from model {}", model.model_name)
-        raise Exception("Failed Inference")
+        response = await client.chat_completion(
+            model=model.model_name,
+            messages=inference_call.messages,
+            temperature=inference_call.temperature,
+        )
 
-    output_content = response.choices[0].message.content
+        if not response or not response.choices:
+            logger.warning("Empty response or missing .choices from model {}", model.model_name)
+            raise Exception("Failed Inference")
+
+        output_content = response.choices[0].message.content
 
     try:
         encoding = _get_encoding(model.encoding_name)

--- a/yourbench/utils/vllm_client.py
+++ b/yourbench/utils/vllm_client.py
@@ -1,0 +1,44 @@
+"""Simple async client for vLLM's OpenAI-compatible API."""
+
+from __future__ import annotations
+import json
+import asyncio
+import urllib.request
+from typing import Any, Dict, List, Optional
+
+
+async def chat_completion(
+    base_url: str,
+    api_key: Optional[str],
+    model: str,
+    messages: List[Dict[str, Any]],
+    temperature: Optional[float] = None,
+    timeout: int = 300,
+    request_id: Optional[str] = None,
+) -> str:
+    """Query a vLLM server's `/chat/completions` endpoint."""
+
+    url = base_url.rstrip("/") + "/chat/completions"
+
+    payload: Dict[str, Any] = {"model": model, "messages": messages}
+    if temperature is not None:
+        payload["temperature"] = temperature
+
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    if request_id:
+        headers["X-Request-ID"] = request_id
+
+    data = json.dumps(payload).encode("utf-8")
+
+    def _post() -> str:
+        req = urllib.request.Request(url, data=data, headers=headers)
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            resp_data = json.loads(resp.read().decode("utf-8"))
+        choices = resp_data.get("choices")
+        if not choices:
+            raise RuntimeError("Empty response from vLLM server")
+        return choices[0]["message"]["content"]
+
+    return await asyncio.to_thread(_post)


### PR DESCRIPTION
## Summary
- support vLLM server endpoints via `vllm` provider
- document new provider
- add usage guide for vLLM API client

## Testing
- `make quality file=.`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'datasets')*

------
https://chatgpt.com/codex/tasks/task_b_683f50eaebb48333b8811b1e289883c4