### PR TITLE
Add pipeline resume and backup options

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -114,6 +114,16 @@ local_dataset_dir: /path/to/local/dataset
 local_dataset_dir: /home/user/yourbench_datasets
 ```
 
+### Backup Dataset Directory
+
+You can maintain a redundant copy of your dataset by specifying `backup_dataset_dir`.
+
+```yaml
+backup_dataset_dir: /path/to/backup
+```
+
+When set, every time a dataset is saved locally, a copy will also be written to this directory.
+
 ---
 
 ## Model Settings
@@ -270,10 +280,26 @@ model_roles:
 The `pipeline` section configures the stages of the YourBench workflow. Each stage can be enabled or disabled and includes additional settings specific to its functionality.
 
 ### Common Options for All Stages
-- **`run`**  
-  - **Type**: Boolean  
-  - **Required**: Yes  
+- **`run`**
+  - **Type**: Boolean
+  - **Required**: Yes
   - **Description**: Enables (`true`) or disables (`false`) the stage.
+
+Additionally, the `pipeline` section supports options to resume execution if a
+previous run was interrupted:
+
+- **`resume`**
+  - **Type**: Boolean
+  - **Optional**: Yes
+  - **Description**: Continue from the last successfully completed stage when set to `true`.
+- **`cache_dir`**
+  - **Type**: String
+  - **Optional**: Yes
+  - **Description**: Directory where pipeline progress is stored.
+- **`reset_cache`**
+  - **Type**: Boolean
+  - **Optional**: Yes
+  - **Description**: If `true`, clears any cached pipeline state before running.
 
 ### Ingestion Stage
 

--- a/example/configs/advanced_example.yaml
+++ b/example/configs/advanced_example.yaml
@@ -54,6 +54,8 @@ hf_configuration:
   # Example:
   # local_dataset_dir: /some/path
   # local_saving: false
+  # backup_dataset_dir: ./backup
+  backup_dataset_dir: ./backup
 
 # ==============================================================================
 # MODEL CONFIGURATION
@@ -141,6 +143,9 @@ model_roles:
 # will execute that stage, while "run: false" will skip it. 
 # For each stage, you can define additional parameters that fine-tune behavior.
 pipeline:
+  resume: true
+  cache_dir: pipeline_cache
+  reset_cache: false
 
   # 1) INGESTION
   # Reads raw documents from disk, attempts to convert them to text, normalizes

--- a/example/configs/simple_example.yaml
+++ b/example/configs/simple_example.yaml
@@ -1,12 +1,15 @@
 hf_configuration:
-  hf_dataset_name: yourbench_example # change this to your desired dataset name
-  private: false # change this to true if you want to make the dataset private. it's true by default.
+  hf_dataset_name: yourbench_example
+  private: false
 
 model_list:
   - model_name: Qwen/Qwen3-30B-A3B
     provider: fireworks-ai
 
 pipeline:
+  resume: true
+  cache_dir: pipeline_cache
+  reset_cache: false
   ingestion:
     source_documents_dir: example/data/raw
     output_dir: example/data/processed

--- a/tests/integration/test_pipeline.py
+++ b/tests/integration/test_pipeline.py
@@ -1,11 +1,15 @@
 import os
+import json
 import shutil
 import tempfile
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from datasets import Dataset
+
+datasets = pytest.importorskip("datasets")  # noqa: E402
+from datasets import Dataset  # noqa: E402
+from yourbench.pipeline.handler import run_pipeline  # noqa: E402
 
 
 # Fixture for temporary directory
@@ -437,3 +441,35 @@ def test_finreg_json_generation_stage(mock_config):
         mock_load.assert_called_once()
         mock_run_inference.assert_called_once()
         mock_save.assert_called_once()
+
+
+def test_pipeline_resume(temp_dir, mock_config):
+    config = mock_config
+    config["pipeline"]["resume"] = True
+    cache_dir = os.path.join(temp_dir, "cache")
+    config["pipeline"]["cache_dir"] = cache_dir
+
+    config_file = os.path.join(temp_dir, "cfg.json")
+    with open(config_file, "w") as f:
+        json.dump(config, f)
+
+    with (
+        patch("yourbench.pipeline.ingestion.run") as mock_ingest,
+        patch("yourbench.pipeline.summarization.run") as mock_sum,
+    ):
+        mock_ingest.return_value = None
+        mock_sum.side_effect = Exception("fail")
+        with pytest.raises(Exception):
+            run_pipeline(config_file)
+        mock_ingest.assert_called_once()
+        mock_sum.assert_called_once()
+
+    with (
+        patch("yourbench.pipeline.ingestion.run") as mock_ingest2,
+        patch("yourbench.pipeline.summarization.run") as mock_sum2,
+    ):
+        mock_ingest2.return_value = None
+        mock_sum2.return_value = None
+        run_pipeline(config_file)
+        mock_ingest2.assert_not_called()
+        mock_sum2.assert_called_once()

--- a/yourbench/pipeline/handler.py
+++ b/yourbench/pipeline/handler.py
@@ -29,6 +29,7 @@
 
 from __future__ import annotations
 import os
+import json
 import time
 import importlib
 from typing import Any, Dict, List
@@ -98,11 +99,43 @@ def run_pipeline(
     # Ensure logs directory exists to store stage-specific logs
     os.makedirs("logs", exist_ok=True)
 
+    # === Resume and caching configuration ===
+    cache_dir = pipeline_config.get("cache_dir", "pipeline_cache")
+    resume_enabled = pipeline_config.get("resume", False)
+    reset_cache = pipeline_config.get("reset_cache", False)
+    os.makedirs(cache_dir, exist_ok=True)
+    state_file = os.path.join(cache_dir, "state.json")
+
+    if reset_cache and os.path.exists(state_file):
+        logger.info("Resetting pipeline cache state.")
+        os.remove(state_file)
+
+    last_completed_stage = None
+    if resume_enabled and os.path.exists(state_file):
+        try:
+            with open(state_file, "r", encoding="utf-8") as f:
+                last_completed_stage = json.load(f).get("last_completed_stage")
+            if last_completed_stage:
+                logger.info(f"Resuming pipeline from stage after '{last_completed_stage}'.")
+        except Exception as e:
+            logger.warning(f"Failed to read state file '{state_file}': {e}")
+
     # Record overall pipeline start
     pipeline_execution_start_time: float = time.time()
 
+    # Determine which stages to run based on resume information
+    if resume_enabled and last_completed_stage in DEFAULT_STAGE_ORDER:
+        start_index = DEFAULT_STAGE_ORDER.index(last_completed_stage) + 1
+        stages_to_run = DEFAULT_STAGE_ORDER[start_index:]
+    else:
+        stages_to_run = DEFAULT_STAGE_ORDER
+
+    if resume_enabled and not stages_to_run:
+        logger.info("All pipeline stages already completed. Nothing to run.")
+        return
+
     # === Execute pipeline stages in the fixed default order ===
-    for stage_name in DEFAULT_STAGE_ORDER:
+    for stage_name in stages_to_run:
         # Check if the stage is mentioned in the pipeline config at all
         if stage_name not in pipeline_config:
             logger.debug(f"Stage '{stage_name}' is not mentioned in the config. Skipping.")
@@ -152,8 +185,19 @@ def run_pipeline(
         })
         logger.success(f"Completed stage: '{stage_name}' in {elapsed_time:.3f}s")
 
+        if resume_enabled:
+            try:
+                with open(state_file, "w", encoding="utf-8") as f:
+                    json.dump({"last_completed_stage": stage_name}, f)
+            except Exception as e:
+                logger.warning(f"Failed to update state file '{state_file}': {e}")
+
     # Record overall pipeline end
     pipeline_execution_end_time: float = time.time()
+
+    if resume_enabled and os.path.exists(state_file):
+        os.remove(state_file)
+        logger.info("Pipeline completed. State file removed.")
 
     # Check for unrecognized stages in config
     _check_for_unrecognized_stages(pipeline_config)

--- a/yourbench/utils/dataset_engine.py
+++ b/yourbench/utils/dataset_engine.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from typing import Any, Dict, Optional
 
 from loguru import logger
@@ -301,11 +302,24 @@ def custom_save_dataset(
             # Save the dataset to disk
             local_dataset.save_to_disk(local_dataset_dir)
             logger.success(f"Dataset successfully saved locally to: '{local_dataset_dir}'")
+
+            backup_dir = config.get("backup_dataset_dir") or config.get("hf_configuration", {}).get(
+                "backup_dataset_dir"
+            )
+            if backup_dir:
+                os.makedirs(backup_dir, exist_ok=True)
+                backup_path = os.path.join(backup_dir, os.path.basename(local_dataset_dir))
+                try:
+                    if os.path.exists(backup_path):
+                        shutil.rmtree(backup_path)
+                    shutil.copytree(local_dataset_dir, backup_path)
+                    logger.info(f"Backup dataset copied to: '{backup_path}'")
+                except Exception as e:
+                    logger.warning(f"Failed to copy backup dataset: {e}")
         except PermissionError as e:
             if "dataset can't overwrite itself" in str(e):
                 # Handle the specific error where a dataset can't overwrite itself
                 logger.warning("Dataset can't overwrite itself. Attempting to save with a temporary directory...")
-                import shutil
                 import tempfile
 
                 # Create a temporary directory


### PR DESCRIPTION
## Summary
- enable pipeline resumption and caching
- support dataset backups when saving locally
- document new options in CONFIGURATION.md
- update example configs for resume & backup
- test resume logic

## Testing
- `ruff format yourbench/pipeline/handler.py yourbench/utils/dataset_engine.py`
- `ruff check --fix yourbench/pipeline/handler.py yourbench/utils/dataset_engine.py`
- `ruff format tests/integration/test_pipeline.py`
- `ruff check --fix tests/integration/test_pipeline.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683f61cca7dc83338eb8142736017d71