### PR TITLE
Add ollama modal script

### DIFF
--- a/example/configs/ollama_6endpoint.yaml
+++ b/example/configs/ollama_6endpoint.yaml
@@ -1,0 +1,43 @@
+hf_configuration:
+  hf_dataset_name: ollama_1000_example
+  private: false
+
+model_list:
+  - model_name: llama3
+    provider: ollama
+    base_url:
+      - http://ollama1.local:11434/v1
+      - http://ollama2.local:11434/v1
+      - http://ollama3.local:11434/v1
+      - http://ollama4.local:11434/v1
+      - http://ollama5.local:11434/v1
+      - http://ollama6.local:11434/v1
+    max_concurrent_requests: 4
+
+model_roles:
+  single_shot_question_generation:
+    - llama3
+
+pipeline:
+  resume: true
+  cache_dir: pipeline_cache
+  reset_cache: false
+  ingestion:
+    source_documents_dir: example/data/raw
+    output_dir: example/data/processed
+  upload_ingest_to_hub:
+  summarization:
+  chunking:
+  single_shot_question_generation:
+    run: true
+    additional_instructions: |
+      Generate a single, self-contained question and answer from each text chunk.
+      Questions should probe moderate-level understanding and include direct
+      citations from the source when possible. Avoid trivial or extremely
+      difficult questions.
+    chunk_sampling:
+      mode: count
+      value: 1000
+  multi_hop_question_generation:
+  lighteval:
+  citation_score_filtering:

--- a/example/configs/ollama_modal_test.yaml
+++ b/example/configs/ollama_modal_test.yaml
@@ -1,0 +1,37 @@
+hf_configuration:
+  hf_dataset_name: ollama_modal_example
+  private: false
+
+model_list:
+  - model_name: llama3
+    provider: ollama
+    base_url: http://OLLAMA_PLACEHOLDER:11434/v1
+    max_concurrent_requests: 2
+
+model_roles:
+  single_shot_question_generation:
+    - llama3
+
+pipeline:
+  resume: true
+  cache_dir: pipeline_cache
+  reset_cache: false
+  ingestion:
+    source_documents_dir: example/data/raw
+    output_dir: example/data/processed
+  upload_ingest_to_hub:
+  summarization:
+  chunking:
+  single_shot_question_generation:
+    run: true
+    additional_instructions: |
+      Generate a single, self-contained question and answer from each text chunk.
+      Questions should probe moderate-level understanding and include direct
+      citations from the source when possible. Avoid trivial or extremely
+      difficult questions.
+    chunk_sampling:
+      mode: count
+      value: 100
+  multi_hop_question_generation:
+  lighteval:
+  citation_score_filtering:

--- a/example/instructions/moderate_question_guidance.md
+++ b/example/instructions/moderate_question_guidance.md
@@ -1,0 +1,3 @@
+Generate a single, self-contained question and answer from each text chunk. Questions should
+probe moderate-level understanding and include direct citations from the source when
+possible. Avoid trivial or extremely difficult questions.

--- a/example/scripts/run_modal_ollama.py
+++ b/example/scripts/run_modal_ollama.py
@@ -1,0 +1,53 @@
+"""Launch an Ollama instance on Modal and run a small YourBench test."""
+
+from __future__ import annotations
+import os
+import tempfile
+import subprocess
+from pathlib import Path
+
+import yaml
+import modal
+
+
+# Modal setup
+stub = modal.Stub("yourbench-ollama-modal")
+
+image = (
+    modal.Image.debian_slim()
+    .apt_install("curl", "gnupg")
+    .run_commands(["curl -fsSL https://ollama.ai/install.sh | sh"])
+)
+
+
+@stub.function(image=image, timeout=60 * 60)
+@modal.web_server(port=11434)
+def ollama_service(model: str) -> None:
+    """Start Ollama and keep serving requests."""
+    import subprocess as sp
+
+    sp.run(["ollama", "pull", model], check=True)
+    sp.run(["ollama", "serve"], check=True)
+
+
+def run_pipeline(base_url: str) -> None:
+    """Run YourBench with the provided base URL."""
+    config_path = Path("example/configs/ollama_modal_test.yaml")
+    cfg = yaml.safe_load(config_path.read_text())
+    cfg["model_list"][0]["base_url"] = base_url
+
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as tmp:
+        yaml.dump(cfg, tmp)
+        tmp_path = Path(tmp.name)
+
+    try:
+        subprocess.run(["yourbench", "run", "--config", str(tmp_path)], check=True)
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    model_name = os.environ.get("OLLAMA_MODEL", "llama3")
+    with stub.run():
+        handle = ollama_service.spawn(model_name)
+        run_pipeline(handle.web_url)

--- a/yourbench/pipeline/single_shot_question_generation.py
+++ b/yourbench/pipeline/single_shot_question_generation.py
@@ -225,9 +225,9 @@ def _build_inference_calls(dataset, stage_config: SingleShotQuestionGenerationCo
 
     for row_index, row in enumerate(dataset):
         doc_row = DocumentRow(
-            document_summary=row.get("document_summary", "No summary available."),
-            document_filename=row.get("document_filename", f"Document_{row_index}"),
-            document_id=row.get("document_id", f"doc_{row_index}"),
+            document_summary=str(row.get("document_summary", "No summary available.")),
+            document_filename=str(row.get("document_filename", f"Document_{row_index}")),
+            document_id=str(row.get("document_id", f"doc_{row_index}")),
             chunks=row.get("chunks", []),
         )
 
@@ -323,9 +323,7 @@ def _process_responses_and_build_dataset(
                     difficulty_val = _force_int_in_range(pair.get("estimated_difficulty", 5), 1, 10)
                     question_type = str(pair.get("question_type", "unknown"))
                     thought_process = str(pair.get("thought_process", ""))
-                    citations = pair.get("citations", [])
-                    if not isinstance(citations, list):
-                        citations = []
+                    citations = _validate_list(pair.get("citations", []))
 
                     if not question_text:
                         logger.debug(f"Empty question found; skipping this QA pair (row_index={row_index}).")


### PR DESCRIPTION
## Summary
- add configuration for testing with a single Modal-hosted Ollama instance
- include a python helper script to launch Ollama on Modal and run the pipeline

## Testing
- `make check file=example/scripts/run_modal_ollama.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684009d39ab48333aa79fd29612beb61